### PR TITLE
Adding offline script runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+offline/
+*.pyc
+*.swp
+src/data/
+src/ref/
+src/pdfs/
+src/pngs/
+src/txts/
+src/db/
+src/temp/
+

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AutoPlotter: http://github.com/jkguiang/AutoPlotter
 - [x] Dynamically displays text files below AutoPlotter toolbar
 - [x] Unique url's for sharing plots pages with the data and reference data set names
 
-## Using AutoDQM
+## Using AutoDQM Web GUI
 
 ###### Setup:
 Clone this repository and move its contents to a public html directory, then run `./setup.sh` to set up AutoDQM's directories.
@@ -56,3 +56,13 @@ Clone this repository and move its contents to a public html directory, then run
 1. Select one of the automatically updated data sets
 2. Use the radio menu to channel selection into either the data or reference form
 3. Click the "Submit" button
+
+## Using AutoDQM Offline
+
+Ensure you have grid certificates under `/etc/grid-security`. Set up a voms proxy with `voms-proxy-init`.
+
+1. Run `./setup.sh` to set up AutoDQM's directories
+2. Call `python ./run-offline.py [sample] [data-run] [ref-run]`
+
+Afterwards, output files are available under `./offline` (by default).
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ AutoPlotter: http://github.com/jkguiang/AutoPlotter
 ###### Setup:
 Clone this repository and move its contents to a public html directory, then run `./setup.sh` to set up AutoDQM's directories.
 
+Set the environment variable `AUTODQM_LOCALDB` to where you would like root files to be cached. If unset, the default is `./src/db`.
+
 ###### Main Page:
 1. Select sample name
     - Currently supported samples: SingleMuon, Cosmics

--- a/run-offline.py
+++ b/run-offline.py
@@ -1,18 +1,21 @@
 from subprocess import call
 from json import dumps
-from os import chdir
+import os
+import argparse
+import shutil
+
 
 def autodqm_offline(sample, data_run, ref_run):
     # Setup parameters
     params = {
-            'sample': 'SingleMuon',
-            'data_info': data_run,
-            'ref_info': ref_run,
-            'user_id': 'offline',
-            }
+        'sample': 'SingleMuon',
+        'data_info': data_run,
+        'ref_info': ref_run,
+        'user_id': 'offline',
+    }
 
     # Change to source directory
-    chdir('src')
+    os.chdir('src')
     do_cmd = './do.sh'
 
     # Run data retrieval and AutoDQM processing
@@ -30,14 +33,39 @@ def autodqm_offline(sample, data_run, ref_run):
     call([do_cmd, params['type'], params['user_id'], dumps(params)])
 
     print("Results are available in the src directory")
+    os.chdir('..')
+
+
+def make_dir(directory):
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+
+def copy_files(fromDir, toDir):
+    for f in os.listdir(fromDir):
+        shutil.copy(fromDir + f, toDir)
+
 
 if __name__ == '__main__':
-    import argparse
     parser = argparse.ArgumentParser(description='Run AutoDQM offline.')
-    parser.add_argument('sample', type=str, help="run sample, one of [Cosmics, SingleMuon]")
+    parser.add_argument('sample', type=str,
+                        help="run sample, one of [Cosmics, SingleMuon]")
     parser.add_argument('data', type=int, help="data run number")
     parser.add_argument('ref', type=int, help="ref run number")
+    parser.add_argument('-o', '--output', default='./offline/',
+                        help="output directory")
     args = parser.parse_args()
 
     autodqm_offline(args.sample, args.data, args.ref)
+
+    # Prepare and move files into output directory
+    make_dir(args.output)
+    make_dir(args.output + '/pdfs')
+    make_dir(args.output + '/pngs')
+    make_dir(args.output + '/txts')
+
+    copy_files('./src/pdfs/offline/', args.output + '/pdfs')
+    copy_files('./src/pngs/offline/', args.output + '/pngs')
+    copy_files('./src/txts/offline/', args.output + '/txts')
+
 

--- a/run-offline.py
+++ b/run-offline.py
@@ -1,0 +1,43 @@
+from subprocess import call
+from json import dumps
+from os import chdir
+
+def autodqm_offline(sample, data_run, ref_run):
+    # Setup parameters
+    params = {
+            'sample': 'SingleMuon',
+            'data_info': data_run,
+            'ref_info': ref_run,
+            'user_id': 'offline',
+            }
+
+    # Change to source directory
+    chdir('src')
+    do_cmd = './do.sh'
+
+    # Run data retrieval and AutoDQM processing
+
+    print("\nRetrieving data root files")
+    params['type'] = 'retrieve_data'
+    call([do_cmd, params['type'], params['user_id'], dumps(params)])
+
+    print("\nRetrieving ref root files")
+    params['type'] = 'retrieve_ref'
+    call([do_cmd, params['type'], params['user_id'], dumps(params)])
+
+    print("\nProcessing files")
+    params['type'] = 'process'
+    call([do_cmd, params['type'], params['user_id'], dumps(params)])
+
+    print("Results are available in the src directory")
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Run AutoDQM offline.')
+    parser.add_argument('sample', type=str, help="run sample, one of [Cosmics, SingleMuon]")
+    parser.add_argument('data', type=int, help="data run number")
+    parser.add_argument('ref', type=int, help="ref run number")
+    args = parser.parse_args()
+
+    autodqm_offline(args.sample, args.data, args.ref)
+

--- a/src/AutoDQM.py
+++ b/src/AutoDQM.py
@@ -86,8 +86,8 @@ def scan_2D(f_hist, r_hist, name, data_id, ref_id, targ_dir):
         pull_hist.Draw("colz")
 
         # Text box
-        data_text = ROOT.TLatex(.52,.91,"#scale[0.6]{Data: "+data_id+"}") 
-        ref_text = ROOT.TLatex(.72,.91,"#scale[0.6]{Ref: "+ref_id+"}") 
+        data_text = ROOT.TLatex(.52,.91,"#scale[0.6]{Data: "+str(data_id)+"}") 
+        ref_text = ROOT.TLatex(.72,.91,"#scale[0.6]{Ref: "+str(ref_id)+"}") 
         data_text.SetNDC(ROOT.kTRUE);
         ref_text.SetNDC(ROOT.kTRUE);
         data_text.Draw()
@@ -180,8 +180,8 @@ def draw_same(f_hist, r_hist, name, data_id, ref_id, targ_dir):
             f_stats.Draw()
 
         # Text box
-        data_text = ROOT.TLatex(.52,.91,"#scale[0.6]{Data: "+data_id+"}") 
-        ref_text = ROOT.TLatex(.72,.91,"#scale[0.6]{Ref: "+ref_id+"}") 
+        data_text = ROOT.TLatex(.52,.91,"#scale[0.6]{Data: "+str(data_id)+"}") 
+        ref_text = ROOT.TLatex(.72,.91,"#scale[0.6]{Ref: "+str(ref_id)+"}") 
         data_text.SetNDC(ROOT.kTRUE);
         ref_text.SetNDC(ROOT.kTRUE);
         data_text.Draw()

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -35,7 +35,7 @@ class HTMLParserRuns(HTMLParser):
 
     def get_run_links(self):
         new_links = []
-        for link in self.links:
+        for link in self.links[1:]: # First link is Up and should be ignored
             # if "/000" not in link: continue
             new_links.append(self.BASE_URL + link)
         return new_links
@@ -110,6 +110,9 @@ def fetch(run, sample, targ_dir):
 
     # Get list of files already in database
     db_dir = "/nfs-6/userdata/bemarsh/CSC_DQM/Run2017/{0}".format(sample)
+    db_dir = os.getenv("AUTODQM_LOCALDB", "./db/") + sample
+    if not os.path.exists(db_dir):
+        os.makedirs(db_dir)
     dbase = os.listdir(db_dir)
 
     temp_dir = "{0}/temp".format(os.getcwd())
@@ -123,7 +126,7 @@ def fetch(run, sample, targ_dir):
 
         # Retrieve run if exists
         for run_link in allRuns:
-            if run[:4] in run_link[0]:
+            if str(run)[:4] in run_link[0]:
                 new_content = get_url_with_cert(run_link[0])
                 new_parser = HTMLParserRuns()
                 new_parser.clear()
@@ -131,14 +134,10 @@ def fetch(run, sample, targ_dir):
                 parsed = new_parser.get_run_linktimestamps()
 
                 for new_link in parsed:
-                    if run in new_link[0]:
-                        get_file_with_cert(new_link[0], "{0}/{1}_temp.root".format(temp_dir, run))
+                    if str(run) in new_link[0]:
+                        get_file_with_cert(new_link[0], "{0}/{1}.root".format(db_dir, run))
 
-
-        f = ROOT.TFile.Open("{0}/{1}_temp.root".format(temp_dir, run))
-
-    else:
-        f = ROOT.TFile.Open("{0}/{1}.root".format(db_dir, run))
+    f = ROOT.TFile.Open("{0}/{1}.root".format(db_dir, run))
     # Recreate file if already exists
     new_f = ROOT.TFile("{0}/{1}.root".format(targ_dir, run), "recreate")
     new_f.Close()

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -109,7 +109,6 @@ def fetch(run, sample, targ_dir):
     ROOT.gErrorIgnoreLevel = ROOT.kWarning
 
     # Get list of files already in database
-    db_dir = "/nfs-6/userdata/bemarsh/CSC_DQM/Run2017/{0}".format(sample)
     db_dir = os.getenv("AUTODQM_LOCALDB", "./db/") + sample
     if not os.path.exists(db_dir):
         os.makedirs(db_dir)


### PR DESCRIPTION
Added a script for running offline and make a few changes to go along with it:

- Fixed a bug where the HTML parser skipped the last root file
- Converted data/ref numbers to strings in a few places, in case they get passed in as numbers
- Made the db configurable by an environment variable
- Root files pulled from the web are now automatically added to the db

Feel free to suggest any changes! Bringing this to the lxplus-dev branch shouldn't be too difficult once it's ready. I haven't added a way to specify what histograms to use compare in this, I figured it should wait until the config file changes are ready on lxplus-dev.