### PR TITLE
Implemented TLS and CERN SSO support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM cern/cc7-base
-EXPOSE 80
+EXPOSE 443
 
 RUN yum update -y && yum install -y \
       ImageMagick \
       httpd \
+      mod_ssl \
       npm \
+      openssl \
       php \
       python2-pip \
       root-python

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,43 @@ RUN yum update -y && yum install -y \
       openssl \
       php \
       python2-pip \
-      root-python
+      root-python \
+      shibboleth \
+      xmltooling-schemas \
+      opensaml-schemas \
+      curl-openssl
 
+# CERN Shibboleth SSO files
+RUN cd /etc/shibboleth && \
+      curl -O http://linux.web.cern.ch/linux/centos7/docs/shibboleth/shibboleth2.xml && \
+      curl -O http://linux.web.cern.ch/linux/centos7/docs/shibboleth/ADFS-metadata.xml && \
+      curl -O http://linux.web.cern.ch/linux/centos7/docs/shibboleth/attribute-map.xml && \
+      curl -O http://linux.web.cern.ch/linux/centos7/docs/shibboleth/wsignout.gif
+RUN chmod 777 /etc/shibboleth/shibboleth2.xml
+
+# Python requirements
 COPY requirements.txt /code/requirements.txt
 RUN pip install -r /code/requirements.txt
 
+# Install create-react-app dependencies
+WORKDIR /webapp
+COPY webapp/package.json /webapp/package.json
+RUN npm install
+
+# Produce a production build of the frontend
+COPY webapp /webapp
+RUN npm run build
+RUN cp -r /webapp/build /var/www/public
+
+# Secrets directory
 RUN mkdir /db /run/secrets
 RUN chown -R apache:apache /db /var/www /run/secrets
 
+# Attach apache logs to docker logs
 RUN ln -s /dev/stdout /etc/httpd/logs/access_log
 RUN ln -s /dev/stderr /etc/httpd/logs/error_log
 
+# Set AutoDQM env vars
 ENV REQUESTS_CA_BUNDLE /etc/ssl/certs/ca-bundle.crt
 ENV ADQM_SSLCERT /run/secrets/cmsvo-cert.pem
 ENV ADQM_SSLKEY /run/secrets/cmsvo-cert.key
@@ -28,20 +54,19 @@ ENV ADQM_PUBLIC /var/www/
 ENV ADQM_CONFIG /var/www/public/config/
 ENV ADQM_PLUGINS /var/www/cgi-bin/plugins/
 
-WORKDIR /webapp
-COPY webapp/package.json /webapp/package.json
-RUN npm install
+# Apache configuration files
+COPY httpd/httpd.conf /etc/httpd/conf/httpd.conf
+COPY httpd/htaccess /var/www/.htaccess
 
-COPY webapp /webapp
-RUN npm run build
-RUN cp -r /webapp/build /var/www/public
-
-COPY httpd.conf /etc/httpd/conf/httpd.conf
+# Backend sources and configuration
 COPY index.py /var/www/cgi-bin/index.py
 COPY autodqm /var/www/cgi-bin/autodqm
 COPY autoref /var/www/cgi-bin/autoref
 COPY plugins /var/www/cgi-bin/plugins
 COPY config /var/www/public/config
 
-CMD ["/usr/sbin/httpd","-D","FOREGROUND"]
+# Run command
+COPY httpd/start.sh ./
+RUN chmod 751 ./start.sh
+CMD ./start.sh
 

--- a/README.md
+++ b/README.md
@@ -24,61 +24,7 @@ AutoDQM parses DQM histograms and identifies outliers by various statistical tes
 
 ## Setting Up AutoDQM for Development
 
-This shows how to set up AutoDQM to be served from your local machine or a machine on CERN OpenStack. This was written based on a fresh CC7 VM on CERN OpenStack. 
-
-You'll need a CERN User/Host certificate authorized with the CMS VO. CMS VO authorization can take ~8 hours so bear that in mind. Certificates can be aquired either from https://cern.ch/ca or, on a CC7 machine, by using auto-enrollment https://ca.cern.ch/ca/Help/?kbid=024000.
-
-Install docker according to https://docs.docker.com/install/ and docker-compose through pip because CC7 has an old versions in it's repositories.
-Enable+start the docker service, and be sure to add your user to the docker group.
-```sh
-sudo yum-config-manager \
-    --add-repo \
-    https://download.docker.com/linux/centos/docker-ce.repo
-sudo yum install docker-ce -y
-sudo yum install python-pip -y
-sudo pip install docker-compose
-```
-```sh
-sudo gpasswd -a [user] docker
-sudo systemctl enable --now docker
-```
-
-You may need to relog into your account before the group settings take effect.
-
-Store your CERN certificate into docker secrets. You may need to extract your cert from PKCS12 format:
-```sh
-openssl pkcs12 -in cern-cert.p12 -out cern-cert.public.pem -clcerts -nokeys
-openssl pkcs12 -in cern-cert.p12 -out cern-cert.private.key -nocerts -nodes
-```
-```sh
-docker swarm init
-docker secret create cmsvo-cert.pem cern-cert.public.pem
-docker secret create cmsvo-cert.key cern-cert.private.key 
-```
-Then initialize a docker swarm, build the autodqm image with docker-compose, and deploy the image as a docker stack
-```sh
-docker-compose build
-docker stack deploy --compose-file=./docker-compose.yml autodqm
-```
-
-You can now view AutoDQM at `http://127.0.0.1`. If you would like to make your instance of AutoDQM public, oopen port 80 to http traffic on your firewall. For example, on CC7:
-```sh
-sudo firewall-cmd --permanent --add-port=80/tcp
-sudo firewall-cmd --reload
-```
-
-After making changes to configuration or source code, rebuild and redeploy the newly built image:
-```sh
-docker-compose build
-docker stack rm autodqm
-docker stack deploy --compose-file=./docker-compose.yml autodqm
-```
-
-If you're using a CC7 image, you may want to disable autoupdate:
-```sh
-sudo systemctl stop yum-autoupdate.service
-sudo systemctl disable yum-autoupdate.service
-```
+More info in the [wiki](https://github.com/jkguiang/AutoDQM/wiki/Development)
 
 ## Using AutoDQM Offline
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: autodqm:latest
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - adqm-db:/db
       - .:/code

--- a/httpd.conf
+++ b/httpd.conf
@@ -17,6 +17,16 @@ Group apache
 ServerAdmin root@localhost
 ServerName localhost
 
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile ${ADQM_SSLCERT}
+    SSLCertificateKeyFile ${ADQM_SSLKEY}
+</VirtualHost>
+
+RewriteEngine On 
+RewriteCond %{HTTPS}  !=on 
+RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L] 
+
 <Directory />
     AllowOverride none
     Require all denied
@@ -49,11 +59,6 @@ DocumentRoot "/var/www/public"
     DirectoryIndex index.html
 </IfModule>
 
-<Directory "${ADQM_TMP}">
-    Options None
-    Require all granted
-</Directory>
-
 <Directory "/var/www/cgi-bin">
     AllowOverride None
     Options None
@@ -62,7 +67,6 @@ DocumentRoot "/var/www/public"
 
 <IfModule alias_module>
     ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
-    Alias /tmp/ "${ADQM_TMP}"
     Alias /results/ "/var/www/results/"
 </IfModule>
 

--- a/httpd/htaccess
+++ b/httpd/htaccess
@@ -1,0 +1,12 @@
+# Shibboleth Configuration
+SSLRequireSSL
+AuthType shibboleth
+ShibRequireSession On
+ShibExportAssertion Off
+
+# Require that the user is a valid CERN user and a member of cms-members
+<RequireAll>
+    Require valid-user
+    Require shib-attr ADFS_GROUP "cms-members"
+</RequireAll>
+

--- a/httpd/httpd.conf
+++ b/httpd/httpd.conf
@@ -3,6 +3,7 @@ Listen 80
 
 Include conf.modules.d/*.conf
 
+# AutoDQM Env Vars
 PassEnv REQUESTS_CA_BUNDLE
 PassEnv ADQM_SSLCERT
 PassEnv ADQM_SSLKEY
@@ -17,12 +18,14 @@ Group apache
 ServerAdmin root@localhost
 ServerName localhost
 
+# TLS VirtualHost
 <VirtualHost *:443>
     SSLEngine on
     SSLCertificateFile ${ADQM_SSLCERT}
     SSLCertificateKeyFile ${ADQM_SSLKEY}
 </VirtualHost>
 
+# Redirect http to https
 RewriteEngine On 
 RewriteCond %{HTTPS}  !=on 
 RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L] 
@@ -35,22 +38,23 @@ RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 DocumentRoot "/var/www/public"
 
 <Directory "/var/www">
-    AllowOverride None
+    AllowOverride All
     Options FollowSymLinks
-    Require all granted
 </Directory>
 
 <Directory "/var/www/public">
     Options Indexes FollowSymLinks
     AllowOverride None
-    Require all granted
 
     # Settings for react router
     RewriteEngine on
-    # Don't rewrite files or directories
+    
+    # Don't rewrite files, directories, or the shibboleth sso endpoint
     RewriteCond %{REQUEST_FILENAME} -f [OR]
-    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteCond %{REQUEST_FILENAME} -d [OR]
+    RewriteCond %{REQUEST_URI} "/Shibboleth.sso*"
     RewriteRule ^ - [L]
+    
     # Rewrite everything else to index.html to allow html5 state links
     RewriteRule ^ index.html [L]
 </Directory>
@@ -62,20 +66,12 @@ DocumentRoot "/var/www/public"
 <Directory "/var/www/cgi-bin">
     AllowOverride None
     Options None
-    Require all granted
 </Directory>
 
 <IfModule alias_module>
     ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
     Alias /results/ "/var/www/results/"
 </IfModule>
-
-
-
-
-<Files ".ht*">
-    Require all denied
-</Files>
 
 ErrorLog "logs/error_log"
 LogLevel warn

--- a/httpd/start.sh
+++ b/httpd/start.sh
@@ -1,0 +1,9 @@
+# Set the hostname of the shibboleth configuration to match the certificate
+hn="$(openssl x509 -noout -subject -in ${ADQM_SSLCERT} | sed -n '/^subject/s/^.*CN=//p')"
+sed -i "s/somehost\.cern\.ch/${hn}/g" /etc/shibboleth/shibboleth2.xml
+
+# Start the shibboleth daemon for SSO
+shibd
+
+# Start the apache process
+httpd -D FOREGROUND

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,12 @@
+#!/bin/sh
+
 # Set the hostname of the shibboleth configuration to match the certificate
 hn="$(openssl x509 -noout -subject -in ${ADQM_SSLCERT} | sed -n '/^subject/s/^.*CN=//p')"
 sed -i "s/somehost\.cern\.ch/${hn}/g" /etc/shibboleth/shibboleth2.xml
 
+# Start the Shibboleth daemon
 shibd
+
+# Start apache in the foreground
 httpd -D FOREGROUND
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+# Set the hostname of the shibboleth configuration to match the certificate
+hn="$(openssl x509 -noout -subject -in ${ADQM_SSLCERT} | sed -n '/^subject/s/^.*CN=//p')"
+sed -i "s/somehost\.cern\.ch/${hn}/g" /etc/shibboleth/shibboleth2.xml
+
+shibd
+httpd -D FOREGROUND
+


### PR DESCRIPTION
Added TLS support using the certificate specified in the docker secrets. Any http requests are redirected to https.

Integrated CERN Single Sign-On as required authentication. This uses the Shibboleth variant that can be configured  at https://sso-management.web.cern.ch/ for new VMs.